### PR TITLE
fix for running all files stand-alone

### DIFF
--- a/easygui/boxes/about.py
+++ b/easygui/boxes/about.py
@@ -6,7 +6,13 @@
 
 """
 
-from .derived_boxes import codebox
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path, sys
+    sys.path.append(path.dirname(path.abspath(__file__)))
+from derived_boxes import codebox
 
 eg_version = '0.97.4alpha-DONT RELEASE'
 egversion = eg_version
@@ -239,3 +245,7 @@ BUG FIXES
    a textbox and a codebox.  This was not a problem for Windows users.
 
 '''
+
+
+if __name__ == "__main__":
+    abouteasygui()

--- a/easygui/boxes/base_boxes.py
+++ b/easygui/boxes/base_boxes.py
@@ -12,9 +12,15 @@ import os
 import sys
 import string
 
-from . import utils as ut
-from .utils import *
-from . import state as st
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path
+    sys.path.append(path.dirname(path.abspath(__file__)))
+import utils as ut
+from utils import *
+import state as st
 
 # Initialize some global variables that will be reset later
 __choiceboxMultipleSelect = None
@@ -1104,4 +1110,4 @@ def __put_buttons_in_buttonframe(choices, default_choice, cancel_choice):
 
 
 if __name__ == '__main__':
-    dm.egdemo()
+    print("Hello from base_boxes")

--- a/easygui/boxes/demo.py
+++ b/easygui/boxes/demo.py
@@ -9,32 +9,41 @@
 import os
 import sys
 
-from . import utils as ut
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path
+    sys.path.append(path.dirname(path.abspath(__file__)))
 
-from .base_boxes import buttonbox
-from .text_box import textbox
-from .base_boxes import diropenbox
-from .base_boxes import fileopenbox
-from .base_boxes import filesavebox
+print(__package__ is None)
 
-from .derived_boxes import ynbox
-from .derived_boxes import ccbox
-from .derived_boxes import boolbox
-from .derived_boxes import indexbox
-from .derived_boxes import msgbox
-from .derived_boxes import integerbox
-from .derived_boxes import multenterbox
-from .derived_boxes import enterbox
-from .derived_boxes import exceptionbox
-from .derived_boxes import choicebox
-from .derived_boxes import codebox
-from .derived_boxes import passwordbox
-from .derived_boxes import multpasswordbox
-from .derived_boxes import multchoicebox
+import utils as ut
 
-from . import about
-from .about import eg_version
-from .about import abouteasygui
+from base_boxes import buttonbox
+from text_box import textbox
+from base_boxes import diropenbox
+from base_boxes import fileopenbox
+from base_boxes import filesavebox
+
+from derived_boxes import ynbox
+from derived_boxes import ccbox
+from derived_boxes import boolbox
+from derived_boxes import indexbox
+from derived_boxes import msgbox
+from derived_boxes import integerbox
+from derived_boxes import multenterbox
+from derived_boxes import enterbox
+from derived_boxes import exceptionbox
+from derived_boxes import choicebox
+from derived_boxes import codebox
+from derived_boxes import passwordbox
+from derived_boxes import multpasswordbox
+from derived_boxes import multchoicebox
+
+import about
+from about import eg_version
+from about import abouteasygui
 
 # --------------------------------------------------------------
 #

--- a/easygui/boxes/derived_boxes.py
+++ b/easygui/boxes/derived_boxes.py
@@ -6,9 +6,16 @@
 
 """
 
-from . import base_boxes as bb
-from . import text_box as tb
-from . import utils as ut
+
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path, sys
+    sys.path.append(path.dirname(path.abspath(__file__)))
+import base_boxes as bb
+import text_box as tb
+import utils as ut
 
 
 # -------------------------------------------------------------------
@@ -541,3 +548,6 @@ def codebox(msg="", title=" ", text=""):
     :param str text: what to display in the textbox
     """
     return tb.textbox(msg, title, text, codebox=1)
+
+if __name__ == '__main__':
+    print("Hello from derived_boxes")

--- a/easygui/boxes/egstore.py
+++ b/easygui/boxes/egstore.py
@@ -156,3 +156,6 @@ of user settings for an EasyGui application.
             key = key.ljust(longest_key_length)
             lines.append("%s : %s\n" % (key, repr(value)))
         return "".join(lines)  # return a string showing the attributes
+
+if __name__ == '__main__':
+    print("Hello from egstore")

--- a/easygui/boxes/text_box.py
+++ b/easygui/boxes/text_box.py
@@ -9,9 +9,15 @@ Version |release|
 
 import sys
 
-from . import utils as ut
-from .utils import *
-from . import state as st
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path
+    sys.path.append(path.dirname(path.abspath(__file__)))
+import utils as ut
+from utils import *
+import state as st
 
 
 def textbox(msg="", title=" ", text="", codebox=0):
@@ -186,8 +192,7 @@ def to_string(something):
     return text
 
 
-def demo_textbox(reply):
-    import boxes.derived_boxes as db
+def demo_textbox():
     text_snippet = ((
         "It was the best of times, and it was the worst of times.  The rich "
         "ate cake, and the poor had cake recommended to them, but wished "
@@ -196,7 +201,7 @@ def demo_textbox(reply):
         * 5) + "\n\n") * 10
     title = "Demo of textbox"
     msg = "Here is some sample text. " * 16
-    reply = db.textbox(msg, title, text_snippet)
+    reply = textbox(msg, title, text_snippet)
     print("Reply was: {!s}".format(reply))
 
 if __name__ == '__main__':

--- a/easygui/boxes/utils.py
+++ b/easygui/boxes/utils.py
@@ -180,3 +180,6 @@ def load_tk_image(filename):
                 msg += "\nPIL library isn't installed.  If it isn't installed, only .gif files can be used."
             raise ValueError(msg)
     return tk_image
+
+if __name__ == '__main__':
+    print("Hello from utils")

--- a/easygui/easygui.py
+++ b/easygui/easygui.py
@@ -86,6 +86,12 @@ __all__ = [
     'eg_version', 'egversion', 'egdemo', 'EgStore'
 ]
 
+# Refs:
+#   https://www.python.org/dev/peps/pep-0366
+#   http://stackoverflow.com/questions/11536764/attempted-relative-import-in-non-package-even-with-init-py
+if __name__ == "__main__" and __package__ is None:
+    from os import path, sys
+    sys.path.append(path.dirname(path.abspath(__file__)))
 # Import all functions that form the API
 from boxes.base_boxes import buttonbox
 from boxes.base_boxes import diropenbox


### PR DESCRIPTION
Hopefully I finally got it correct.  Now, not only can the easygui
module be used, but the individual files in boxes, for instance, can run
on their own.  Sometimes they don't do much, but at least the shell is
ready for them to run their __main__.  Changed the text_box.py making
some corrections in the demo, but I may not have gotten them correct.

I will push these changes to master.