### PR TITLE
Fixes for #97 and #99

### DIFF
--- a/easygui/boxes/button_box.py
+++ b/easygui/boxes/button_box.py
@@ -408,6 +408,8 @@ class GUItk(object):
             state=tk.DISABLED,
             padx=(global_state.default_hpad_in_chars) *
             self.calc_character_width(),
+            relief="flat",
+            background=self.boxRoot.config()["background"][-1],
             pady=global_state.default_hpad_in_chars *
             self.calc_character_width(),
             wrap=tk.WORD,

--- a/easygui/boxes/button_box.py
+++ b/easygui/boxes/button_box.py
@@ -408,6 +408,8 @@ class GUItk(object):
             state=tk.DISABLED,
             padx=(global_state.default_hpad_in_chars) *
             self.calc_character_width(),
+            background="SystemButtonFace",
+            relief="flat",
             pady=global_state.default_hpad_in_chars *
             self.calc_character_width(),
             wrap=tk.WORD,

--- a/easygui/boxes/button_box.py
+++ b/easygui/boxes/button_box.py
@@ -408,8 +408,6 @@ class GUItk(object):
             state=tk.DISABLED,
             padx=(global_state.default_hpad_in_chars) *
             self.calc_character_width(),
-            background="SystemButtonFace",
-            relief="flat",
             pady=global_state.default_hpad_in_chars *
             self.calc_character_width(),
             wrap=tk.WORD,

--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -325,6 +325,8 @@ class GUItk(object):
             self.msgFrame,
             width=self.width_in_chars,
             state=tk.DISABLED,
+            background='SystemButtonFace',
+            relief='flat',
             padx=(global_state.default_hpad_in_chars *
                   self.calc_character_width()),
             pady=(global_state.default_hpad_in_chars *

--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -325,6 +325,8 @@ class GUItk(object):
             self.msgFrame,
             width=self.width_in_chars,
             state=tk.DISABLED,
+            background=self.boxRoot.config()["background"][-1],
+            relief='flat',
             padx=(global_state.default_hpad_in_chars *
                   self.calc_character_width()),
             pady=(global_state.default_hpad_in_chars *

--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -325,8 +325,6 @@ class GUItk(object):
             self.msgFrame,
             width=self.width_in_chars,
             state=tk.DISABLED,
-            background='SystemButtonFace',
-            relief='flat',
             padx=(global_state.default_hpad_in_chars *
                   self.calc_character_width()),
             pady=(global_state.default_hpad_in_chars *

--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -73,7 +73,7 @@ def make_list_or_none(obj, cast_type=None):
         if cast_type is not None:
             try:
                 ret_val = cast_type(obj)
-            except Exception, e:
+            except Exception as e:
                 raise Exception("Value {} cannot be converted to type: {}".format(obj, cast_type))
         ret_val = [ret_val,]
     # Convert all elements to cast_type


### PR DESCRIPTION
This includes the fix the Python 3 SyntaxError issue #97 

Also fixes the message area for text widgets mentioned in issue #99 
The fix makes sets the background of the text widget to the background value of the `boxRoot` background so that the text widget used for the MessageArea takes on an appearance closer to the Message widget. --  this fix works across platforms.

Tested on Windows 7 and Ubuntu

Win7:
![newbox](https://cloud.githubusercontent.com/assets/15212758/18840360/4e505d98-83dc-11e6-9a1d-e6d91020204b.JPG)

Ubuntu:

![newboxubuntu](https://cloud.githubusercontent.com/assets/15212758/18840371/53562890-83dc-11e6-8a82-9112bd8ec20f.JPG)

