### PR TITLE
Message height fix

### DIFF
--- a/easygui/boxes/button_box.py
+++ b/easygui/boxes/button_box.py
@@ -318,7 +318,7 @@ class GUItk(object):
         lines = message_content.split("\n")
         width = self.messageArea["width"]
         num_lines = len(lines)
-        num_wordwraps = sum([len(line) // width for line in lines if len(line) != width])
+        num_wordwraps = sum(len(line) // width for line in lines if len(line) != width)
         height = num_lines + num_wordwraps + 1
         self.messageArea.configure(height=height)
 

--- a/easygui/boxes/button_box.py
+++ b/easygui/boxes/button_box.py
@@ -310,17 +310,17 @@ class GUItk(object):
         self.messageArea.config(state=tk.DISABLED)
         # Adjust msg height
         self.messageArea.update()
-        numlines = self.get_num_lines(self.messageArea)
-        self.set_msg_height(numlines)
+        self.set_msg_height()
         self.messageArea.update()
 
-    def set_msg_height(self, numlines):
-        self.messageArea.configure(height=numlines)
-
-    def get_num_lines(self, widget):
-        end_position = widget.index(tk.END)  # '4.0'
-        end_line = end_position.split('.')[0]  # 4
-        return int(end_line) + 1  # 5
+    def set_msg_height(self):
+        message_content = self.messageArea.get("1.0", tk.END)
+        lines = message_content.split("\n")
+        width = self.messageArea["width"]
+        num_lines = len(lines)
+        num_wordwraps = sum([len(line) // width for line in lines if len(line) != width])
+        height = num_lines + num_wordwraps + 1
+        self.messageArea.configure(height=height)
 
     def set_pos(self, pos):
         self.boxRoot.geometry(pos)


### PR DESCRIPTION
Fixed issue where message height is incorrect because of word wrapping. Addresses #114 

Not perfect*, but better than the original behavior.  There are some cases where extra lines are added, such as when the line length is exactly some multiple (>1) of the width of the messageArea.

*For instance, with the default width of 80, a line that's *exactly* 160 characters will unnecessarily increase the height by 1