### PR TITLE
Fix ghost window on diropenbox for Mac

### DIFF
--- a/easygui/boxes/diropen_box.py
+++ b/easygui/boxes/diropen_box.py
@@ -45,6 +45,7 @@ def diropenbox(msg=None, title=None, default=None):
     localRoot.withdraw()
     if not default:
         default = None
+    localRoot.update() #fix ghost window issue on mac.
     f = ut.tk_FileDialog.askdirectory(
         parent=localRoot, title=title, initialdir=default, initialfile=None
     )


### PR DESCRIPTION
This resolves issue #118 I brought up. Window will clear after the dir has been selected.