### PR TITLE
Remove Debug Print

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -270,7 +270,7 @@ class GUItk(object):
         global_state.window_position = '+' + geom.split('+', 1)[1]
 
     def preselect_choice(self, preselect):
-        print(preselect)
+        #print(preselect)
         if preselect != None:
             for v in preselect:
                 self.choiceboxWidget.select_set(v)


### PR DESCRIPTION
The Debug Print in the "preselect_choice" Function constantly prints an zero array into the console when called "[0]" ...this is slightly unfortunate when trying to keep a neat and tidy console output. A removal would be appreciated. I'd just change it myself in the site-packages but whoever wants to use my code and pip-install your library with it will have the same problem again. Thanks in advance! :)