### PR TITLE
destroy filebox if none value returned

### DIFF
--- a/easygui/boxes/fileopen_box.py
+++ b/easygui/boxes/fileopen_box.py
@@ -107,6 +107,7 @@ def fileopenbox(msg=None, title=None, default='*', filetypes=None, multiple=Fals
                    filetypes=filetypes
                    )
     if not ret_val or ret_val == '':
+        localRoot.destroy()
         return None
     if multiple:
         f = [os.path.normpath(x) for x in localRoot.tk.splitlist(ret_val)]


### PR DESCRIPTION
Currently, if the file open box is closed by hitting the 'x' or 'Cancel' buttons, the box returns None but doesn't destroy the tk object. This commit fixes that.

Not closing the tk object cases an issue when using tk in conjunction with matplotlib, as described [here](https://stackoverflow.com/a/48470826/6457747).

I don't believe any additional testing code is required, do let me know if that is not the case or if I should request this change in a different manner.

Thank you!