### PR TITLE
Fix whitespace typo in choice_box.py

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -205,7 +205,7 @@ class GUItk(object):
 
         self.create_cancel_button()
 
-        self. create_special_buttons()
+        self.create_special_buttons()
         
         self.preselect_choice(preselect)
 


### PR DESCRIPTION
Fix whitespace typo in choice_box.py.
Might fix issues with special buttons not getting created if there were any.