### PR TITLE
Make version comparison look at major and minor versions.

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -1,7 +1,7 @@
 import string
 import sys
 
-if sys.version_info.minor < 10:
+if sys.version_info < (3, 10):
     from collections import Sequence
 else:
     from collections.abc import Sequence


### PR DESCRIPTION
Sequence moved from collections to collections.abc back in v3.3
It has been available through collections until v3.9.
From v3.10 onwards it needs to be imported from the right place

Minor change here to amend the version check to use major and minor version.