### PR TITLE
fix issue #189: make sphinx/conf.py python 3 friendly

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -273,8 +273,8 @@ texinfo_documents = [
 def suppress_module_docstring(app, what, name, obj, options, lines):
 
   if what == 'module':
-    print len(lines)
-    for i in xrange(len(lines)):
+    print(len(lines))
+    for i in range(len(lines)):
       del lines[-1]
   pass
 
@@ -282,9 +282,9 @@ def functions_to_headers(app, what, name, obj, options, lines):
   if what == 'function':
     lines.insert(0,'.. py:function:: freddy')  # Not needed
     lines.insert(1,'')
-    print lines[0]
-    print obj
-    print options
+    print(lines[0])
+    print(obj)
+    print(options)
 
 
 def setup(app):


### PR DESCRIPTION
@anoteng - I think that this is the content of your suggested patch

Does it look okay to you?

Using range vs xrange for Python2 does introduce a material difference … but since we’re unlikely to ever go to *big* iterables there having a list rather than a range object seems reasonable for the benefit of having more modern looking code…