### PR TITLE
Solved the problem that easygui-choicebox does not work in python3.10

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -1,7 +1,7 @@
 import string
 import sys
 
-if sys.version_info < (3, 10):
+if sys.version_info.major < (3) and sys.version_info.minor  (10):
     from collections import Sequence
 else:
     from collections.abc import Sequence

--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -1,7 +1,7 @@
 import string
 import sys
 
-if sys.version_info.major < (3) and sys.version_info.minor  (10):
+if sys.version_info.major < (3) and sys.version_info.minor < (10):
     from collections import Sequence
 else:
     from collections.abc import Sequence


### PR DESCRIPTION
I have successfully tested with the following example:
```
import easygui
easygui.choicebox("What's your favourite food?" ,
choices = ['noodles','cookies','beef'])