### PR TITLE
use a consistent way to give focus fileopenbox / diropenbox / filesavebox

### DIFF
--- a/easygui/boxes/diropen_box.py
+++ b/easygui/boxes/diropen_box.py
@@ -42,9 +42,7 @@ def diropenbox(msg=None, title=None, default=None):
     title = ut.getFileDialogTitle(msg, title)
     localRoot = tk.Tk()
     localRoot.withdraw()
-    localRoot.lift()
-    localRoot.attributes('-topmost', 1)
-    localRoot.attributes('-topmost', 0)
+    localRoot.attributes("-topmost", True)
     if not default:
         default = None
     localRoot.update() #fix ghost window issue #119 on mac.

--- a/easygui/boxes/filesave_box.py
+++ b/easygui/boxes/filesave_box.py
@@ -65,6 +65,7 @@ def filesavebox(msg=None, title=None, default="", filetypes=None):
 
     localRoot = tk.Tk()
     localRoot.withdraw()
+    localRoot.attributes("-topmost", True)
 
     initialbase, initialfile, initialdir, filetypes = fbs.fileboxSetup(
         default, filetypes)


### PR DESCRIPTION
... this is the same change as PR #163 - for the other two boxes in the 'family'
These three boxes all delegate the window behaviour to an underlying Tk method.
We *want* to .withdraw() our Tk root window; we also want the delegated window to get focus.