### PR TITLE
import sooner from collections.abc (#204)

### DIFF
--- a/easygui/boxes/choice_box.py
+++ b/easygui/boxes/choice_box.py
@@ -3,7 +3,7 @@ import sys
 
 from easygui.boxes.utils import mouse_click_handlers
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 3):
     from collections import Sequence
 else:
     from collections.abc import Sequence


### PR DESCRIPTION
As discussed in #204, a warning pops each time when using this project. This patch fixes it.