### PR TITLE
Bugfix: pressing arrows generates `AttributeError`

### DIFF
--- a/easygui/boxes/base_boxes.py
+++ b/easygui/boxes/base_boxes.py
@@ -20,8 +20,10 @@ def bindArrows(widget):
 
 
 def tabRight(event):
-    boxRoot.event_generate("<Tab>")
+    if boxRoot:
+        boxRoot.event_generate("<Tab>")
 
 
 def tabLeft(event):
-    boxRoot.event_generate("<Shift-Tab>")
+    if boxRoot:
+        boxRoot.event_generate("<Shift-Tab>")


### PR DESCRIPTION
More info about the bug: I used the easygui.enterbox, and while pressing the left/right/up/down arrows - easygui generated these weird errors to me:
```python
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Users\tomhe\AppData\Local\Programs\Python\Python311\Lib\tkinter\__init__.py", line 1948, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "C:\Users\tomhe\AppData\Local\Programs\Python\Python311\Lib\site-packages\easygui\boxes\base_boxes.py", line 23, in tabRight
    boxRoot.event_generate("<Tab>")
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'event_generate'
```

It seems like the exact problem in #170.

This Pull Request is a solution to that problem. I tested it and it works for me.
It's only two new `if`s to the codebase so it should be very simple to verify.

I also strongly believe that this bugfix should be deployed now by creating version 0.98.4 (I know I would love to use this library with the fixed bug).